### PR TITLE
Fixed bomb.rs

### DIFF
--- a/bomb.rs
+++ b/bomb.rs
@@ -1,14 +1,8 @@
 // bomb.rs
-// Andrew Pennebaker
+// Chad Sharp
 
-use std;
-
-fn bomb() {
-  while true {
-    task::spawn(bomb);
-  }
-}
-
+#[allow(unconditional_recursion)]
 fn main() {
-  task::spawn(bomb);
+    std::thread::spawn(main);
+    main();
 }


### PR DESCRIPTION
Forkbomb now compiles (task has been deprecated). `use std` is no longer necessary. Also, removed compiler warnings about infinite recursion